### PR TITLE
Adding new variables

### DIFF
--- a/.cicd/manifests/config-map.yaml
+++ b/.cicd/manifests/config-map.yaml
@@ -58,3 +58,6 @@ data:
   EMAIL_TRANSPORT: {{.Values.emailTransport}}
   EMAIL_SENDMAIL_NEW_LINE: {{.Values.emailSendmailNewLine}}
   EMAIL_SENDMAIL_PATH: {{.Values.emailSendmailPath}}
+  EMAIL_SES_CREDENTIALS_ACCESS_KEY_ID: {{.Values.emailSesCredentialsAccessKeyId}}
+  EMAIL_SES_CREDENTIALS_SECRET_ACCESS_KEY: {{.Values.emailSesCredentialsSecretAccessKey}}
+  EMAIL_SES_REGION: {{.Values.emailSesRegion}}

--- a/.cicd/values.yaml
+++ b/.cicd/values.yaml
@@ -76,9 +76,13 @@ corsMaxAge: <+serviceVariables.corsMaxAge>
 extensionsPath: <+serviceVariables.extensionsPath>
 extensionsAutoReload: <+serviceVariables.extensionsAutoReload>
 
-## Email (not used)
+## Email
 emailFrom: <+serviceVariables.emailFrom>
 emailTransport: <+serviceVariables.emailTransport>
 
 emailSendmailNewLine: <+serviceVariables.emailSendmailNewLine>
 emailSendmailPath: <+serviceVariables.emailSendmailPath>
+
+emailSesCredentialsAccessKeyId: <+serviceVariables.emailSesCredentialsAccessKeyId>
+emailSesCredentialsSecretAccessKey: <+serviceVariables.emailSesCredentialsSecretAccessKey>
+emailSesRegion: <+serviceVariables.emailSesRegion>


### PR DESCRIPTION
https://github.com/casper-network/sre/issues/643

This PR adds the required variables for switching to AWS SES.
The vars have been added (emailSesCredentialsAccessKeyId, emailSesCredentialsSecretAccessKey and emailSesRegion) / modified (emailTransport changed from "sendmail" to "ses" as per suggestion from Sandro).

